### PR TITLE
Allow array options

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -546,7 +546,6 @@ class Task extends \ExecTask {
    * {@inheritdoc}
    */
   protected function buildCommand() {
-
     $this->realCommand = implode(' ', $this->commandline->getCommandline());
 
     if ($this->error !== NULL) {

--- a/src/Task.php
+++ b/src/Task.php
@@ -521,8 +521,7 @@ class Task extends \ExecTask {
     }
 
     foreach ($this->options as $option) {
-      // Trick to ensure no option duplicates.
-      $options[$option->getName()] = $option->toString();
+      $options[] = $option->toString();
     }
     // Sort options alphabetically.
     asort($options);

--- a/src/Task.php
+++ b/src/Task.php
@@ -519,13 +519,7 @@ class Task extends \ExecTask {
       $this->setCheckreturn(FALSE);
       $this->optionRemove('pretend');
     }
-
-    foreach ($this->options as $option) {
-      $options[] = $option->toString();
-    }
-    // Sort options alphabetically.
-    asort($options);
-    $this->commandline->addArguments(array_values($options));
+    $this->commandline->addArguments($this->options);
 
     /*
      * The parameters.

--- a/src/Task.php
+++ b/src/Task.php
@@ -519,7 +519,11 @@ class Task extends \ExecTask {
       $this->setCheckreturn(FALSE);
       $this->optionRemove('pretend');
     }
-    $this->commandline->addArguments($this->options);
+
+    foreach ($this->options as $option) {
+      $options[] = $option->toString();
+    }
+    $this->commandline->addArguments($options);
 
     /*
      * The parameters.
@@ -542,6 +546,7 @@ class Task extends \ExecTask {
    * {@inheritdoc}
    */
   protected function buildCommand() {
+
     $this->realCommand = implode(' ', $this->commandline->getCommandline());
 
     if ($this->error !== NULL) {


### PR DESCRIPTION
Allow running Drush commands with options as array:

```
$ drush some-cmd --value=1 --value=2 --value=3
```